### PR TITLE
Configure VS Code's recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "DigitalBrainstem.javascript-ejs-support",
+    "denoland.vscode-deno"
+  ]
+}


### PR DESCRIPTION
This'll make it easier for people who missed the first session (where we
setup VS Code) to get going, popping up a prompt to install extensions
that are relevant to the tech we're using on the project.

The deno extensions gives us editor support for the syntax highlighting,
type errors, and completion, via the Deno language server.

The EJS extension makes it a bit quicker to write .ejs templates. Type
"ejs" within the text of a .ejs template to trigger the list of things
it can help you type.
