### PR TITLE
Simplify and fix return code of 'deno task test'

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,7 @@
 {
   "tasks": {
     "dev": "deno run --allow-all --watch main.ts",
-    "shutdown": "kill $(lsof -t -i :8081)",
-    "test": "sleep 0.5 && (deno test --allow-all; deno task shutdown) & (PORT=8081 deno task dev || true)"
+    "test": "./test.sh"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Our test suite needs our web server to be running in order for it work.
+#
+# This script:
+#
+# - starts a server
+# - runs our tests against it
+# - stops the server
+#
+# We need to be able to do all these steps via a single command so that
+# GitHub Actions (where we're running our Continuous Integration) can
+# run the tests properly.
+
+# We're running it on a port that won't clash with the default port,
+# that could already be in use if we're running the server locally.
+#
+export PORT=8081
+
+# Start a server (which knows to check the value of PORT)
+#
+# Note the "&" at the end of the command will cause it to run "in the
+# background", which will allow the rest of this script to carry on
+# running while the server starts up.
+deno task dev &
+
+# Give the server a split second to get ready, then run the tests.
+#
+# Note that our tests also check the value of PORT, to work out which
+# server to connect to.
+sleep 0.5
+deno test --allow-all
+
+# We need to know whether those tests passed so we can report it to
+# GitHub Actions, so we'll capture the "exit code" of the last command.
+# The previous command's exit code is stored in the "?" variable.
+PASSED=$?
+
+# Get the process ID of the server, then kill it
+PID="$(lsof -t -i :$PORT)"
+kill "$PID"
+
+# Report whether the tests passed or failed (GitHub Actions checks this
+# script's exit status to decide whether the build should go red, or green)
+exit $PASSED


### PR DESCRIPTION
Despite having tested the complicated one-line command that I wrote for the test task, it didn't work properly. When the tests fail, it exits with a successful exit code (i.e. 0).

I managed to edit the command so that it worked when run in a terminal (which uses Bash), but when run via `deno task test` my new command still didn't work. I think Deno has its own built-in shell command parsing library, which seems to have different rules for working out the exit code.

Why didn't I think of doing it like this in the first place?!